### PR TITLE
Adding version 1.6.5, 1.7.0, 1.7.3

### DIFF
--- a/templates/quickstart-eks-hashicorp-vault.template.yml
+++ b/templates/quickstart-eks-hashicorp-vault.template.yml
@@ -107,6 +107,9 @@ Parameters:
     Description: Version of Vault to use.
     AllowedValues: 
      - "1.6.0"
+     - "1.6.5"
+     - "1.7.0"
+     - "1.7.3"
   VaultDeploymentSize:
     Type: String
     Default: "small"


### PR DESCRIPTION
The helm chart that is deployed is the latest but the tag parameter for the version is currently static to 1.6.0 perhaps there is a reason for this, however it would be useful to be able to test the new versions that have bugfixes