### PR TITLE
Download submodules via https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "submodules/quickstart-aws-acm-certificate"]
 	path = submodules/quickstart-aws-acm-certificate
-	url = git@github.com:aws-quickstart/quickstart-aws-acm-certificate.git
+	url = https://github.com/aws-quickstart/quickstart-aws-acm-certificate.git
 	branch = main
 [submodule "submodules/quickstart-amazon-eks-nodegroup"]
 	path = submodules/quickstart-amazon-eks-nodegroup
-	url = git@github.com:aws-quickstart/quickstart-amazon-eks-nodegroup.git
+	url = https://github.com/aws-quickstart/quickstart-amazon-eks-nodegroup.git
 	branch = main
 [submodule "docs/boilerplate"]
 	path = docs/boilerplate


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Modify submodule download URLs to https instead of ssh so companies (whose firewalls only allow https) can download these submodules.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
